### PR TITLE
Commafix

### DIFF
--- a/wsgi/openshift/contest/templates/viewTeams/viewTeams.html
+++ b/wsgi/openshift/contest/templates/viewTeams/viewTeams.html
@@ -33,13 +33,9 @@
     		</small>
     		</li>    		
     		<small><p class="text-muted">{{ team.leader.get_name_nick }},</small>
-    		{% for member in team.members.all%}    	
-	    		{% if member = team.leader %}
-	    		{% else %}
-	    			{{ member.get_name_nick }},
-	    		{% endif %}
-	    	{% endfor %}
-    		</ul>	    	
+            {{ team.members.all | join:',' }}
+
+       		</ul>	    	
 	    	</p>
 	    	<br>
 	{% endfor %}

--- a/wsgi/openshift/contest/templates/viewTeams/viewTeams.html
+++ b/wsgi/openshift/contest/templates/viewTeams/viewTeams.html
@@ -33,7 +33,18 @@
     		</small>
     		</li>    		
     		<small><p class="text-muted">{{ team.leader.get_name_nick }},</small>
-            {{ team.members.all | join:',' }}
+
+            {% for member in team.members.all%}      
+                {% if member = team.leader %}
+                {% else %}
+                    {% if not forloop.last %}
+                        {{ member.get_name_nick }},
+                    {% else %}
+                        {{ member.get_name_nick }}
+                    {% endif %}
+                {% endif %}
+            {% endfor %}
+        </ul>        
 
        		</ul>	    	
 	    	</p>


### PR DESCRIPTION
no comma on last member. Are we still supposed to display the leader with _small_ text?
