### PR TITLE
Make contest page button visible for staff

### DIFF
--- a/wsgi/openshift/contest/templates/contest/team.html
+++ b/wsgi/openshift/contest/templates/contest/team.html
@@ -10,14 +10,12 @@
 			<h2>Team page</h2>
 		</span>
 		<span class= "pull-right">
-		{% if contest_started %}
+		{% if contest_started or user.is_staff%}
 			<span data-toggle="tooltip" data-placement="left" title="Press this button to go to the contest page">
 			<a href="{% url 'submission_page' contest.url %}" class="btn btn-primary btn-large">{% trans 'Go To Contest Page' %}</a>
-			</span>
-		{% elif user.is_staff %}
-			<span data-toggle="tooltip" data-placement="left" title="Press this button to go to the contest page, as staff">
-			<a href="{% url 'submission_page' contest.url %}" class="btn btn-primary btn-large">{% trans 'Go To Contest Page' %}</a>
-			<p><small>Check it out as staff</small><p>
+			{% if not contest_started %}
+				<p><small>Check it out as staff</small><p>
+			{% endif %}
 			</span>
 		{% else %}
 			<span data-toggle="tooltip" data-placement="left" title="This button will be enabled when the contest starts">

--- a/wsgi/openshift/contest/templates/contest/team.html
+++ b/wsgi/openshift/contest/templates/contest/team.html
@@ -14,6 +14,11 @@
 			<span data-toggle="tooltip" data-placement="left" title="Press this button to go to the contest page">
 			<a href="{% url 'submission_page' contest.url %}" class="btn btn-primary btn-large">{% trans 'Go To Contest Page' %}</a>
 			</span>
+		{% elif is_staff %}
+			<span data-toggle="tooltip" data-placement="left" title="Press this button to go to the contest page, as staff">
+			<a href="{% url 'submission_page' contest.url %}" class="btn btn-primary btn-large">{% trans 'Go To Contest Page' %}</a>
+			<p><small>Check it out as staff</small><p>
+			</span>
 		{% else %}
 			<span data-toggle="tooltip" data-placement="left" title="This button will be enabled when the contest starts">
 			<a href="{% url 'submission_page' contest.url %}" class="btn btn-info btn-large disabled">{% trans 'Go To Contest Page' %}</a>

--- a/wsgi/openshift/contest/templates/contest/team.html
+++ b/wsgi/openshift/contest/templates/contest/team.html
@@ -14,7 +14,7 @@
 			<span data-toggle="tooltip" data-placement="left" title="Press this button to go to the contest page">
 			<a href="{% url 'submission_page' contest.url %}" class="btn btn-primary btn-large">{% trans 'Go To Contest Page' %}</a>
 			</span>
-		{% elif is_staff %}
+		{% elif user.is_staff %}
 			<span data-toggle="tooltip" data-placement="left" title="Press this button to go to the contest page, as staff">
 			<a href="{% url 'submission_page' contest.url %}" class="btn btn-primary btn-large">{% trans 'Go To Contest Page' %}</a>
 			<p><small>Check it out as staff</small><p>

--- a/wsgi/openshift/contest/views.py
+++ b/wsgi/openshift/contest/views.py
@@ -249,7 +249,6 @@ def team_profile(request):
                        'addMemberForm' : addMemberForm,
                         'is_leader' : leader,
                        'contest_started' : contest_started,
-                       'is_staff': user.is_staff
                        }
             return render(request, 'contest/team.html', context)
         # If you are the leader
@@ -273,14 +272,12 @@ def team_profile(request):
                        'addMemberForm' : addMemberForm,
                        'is_leader' : leader,
                        'invites' : invites,
-                       'is_staff': user.is_staff,
                        }
         # If user is not leader, send context without addMemberForm
         else:
             context = {'team':team,
                        'is_leader' : leader,
                        'invites' : invites,
-                       'is_staff': user.is_staff,
                        }
     # If you don't have team, send an empty context
     else:

--- a/wsgi/openshift/contest/views.py
+++ b/wsgi/openshift/contest/views.py
@@ -249,6 +249,7 @@ def team_profile(request):
                        'addMemberForm' : addMemberForm,
                         'is_leader' : leader,
                        'contest_started' : contest_started,
+                       'is_staff': user.is_staff
                        }
             return render(request, 'contest/team.html', context)
         # If you are the leader
@@ -272,12 +273,14 @@ def team_profile(request):
                        'addMemberForm' : addMemberForm,
                        'is_leader' : leader,
                        'invites' : invites,
+                       'is_staff': user.is_staff,
                        }
         # If user is not leader, send context without addMemberForm
         else:
             context = {'team':team,
                        'is_leader' : leader,
                        'invites' : invites,
+                       'is_staff': user.is_staff,
                        }
     # If you don't have team, send an empty context
     else:


### PR DESCRIPTION
template now checks if user is staff, if it is the "go to contest page" will be visible even if the contest has not yet started
